### PR TITLE
Resolve dependency conflict with latest version of scipy (1.15+)

### DIFF
--- a/nbs/05_analysis.ipynb
+++ b/nbs/05_analysis.ipynb
@@ -141,7 +141,6 @@
     "        n_padded_frames = int(np.median(widths)) + 1\n",
     "        signal_padded_with_reflection = np.pad(self.mean_intensity_over_time, n_padded_frames, 'reflect')\n",
     "        frame_idxs_of_peaks_in_padded_signal = signal.find_peaks_cwt(vector = signal_padded_with_reflection, \n",
-    "                                                         wavelet = signal.ricker, \n",
     "                                                         widths = widths, \n",
     "                                                         min_length = min_length,\n",
     "                                                         max_distances = widths / 4, # default\n",

--- a/neuralactivitycubic/__init__.py
+++ b/neuralactivitycubic/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from neuralactivitycubic.controller import open_gui

--- a/neuralactivitycubic/analysis.py
+++ b/neuralactivitycubic/analysis.py
@@ -84,7 +84,6 @@ class AnalysisROI:
         n_padded_frames = int(np.median(widths)) + 1
         signal_padded_with_reflection = np.pad(self.mean_intensity_over_time, n_padded_frames, 'reflect')
         frame_idxs_of_peaks_in_padded_signal = signal.find_peaks_cwt(vector = signal_padded_with_reflection, 
-                                                         wavelet = signal.ricker, 
                                                          widths = widths, 
                                                          min_length = min_length,
                                                          max_distances = widths / 4, # default

--- a/settings.ini
+++ b/settings.ini
@@ -5,7 +5,7 @@
 ### Python library ###
 repo = NeuralActivityCubic
 lib_name = neuralactivitycubic
-version = 0.1.0
+version = 0.1.1
 min_python = 3.11
 license = AGPL-3.0
 black_formatting = False
@@ -38,7 +38,7 @@ status = 3
 user = ddoll
 
 ### Optional ###
-requirements = jupyterlab>=4.2.3 ipywidgets>=8.0.4 ipyfilechooser>=0.6.0 imageio>=2.31.4 imageio-ffmpeg>=0.4.9 matplotlib>=3.8.0 scipy<1.12 numpy<2 pandas>=2.2.1 pybaselines>=1.1.0 roifile>=2024.5.24 shapely>=2.0.1 scikit-image>=0.22.0
+requirements = jupyterlab>=4.2.3 ipywidgets>=8.0.4 ipyfilechooser>=0.6.0 imageio>=2.31.4 imageio-ffmpeg>=0.4.9 matplotlib>=3.8.0 scipy>=1.15.3 numpy>=2.2.5 pandas>=2.2.1 pybaselines>=1.1.0 roifile>=2024.5.24 shapely>=2.0.1 scikit-image>=0.22.0
 # dev_requirements = 
 # console_scripts =
 # conda_user = 


### PR DESCRIPTION
In latest versions of scipy, the scipy.signal.ricker was deprecated, causing an error when running neuralactivitycubic. However, since scipy.signal.find_peaks_cwt() was also changed to use the ricker wavelet by default, this could safely be removed - resolving the dependency issue while maintaining the exact same processing.